### PR TITLE
Iss 25

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -14,7 +14,7 @@ export default async function Page() {
     const user = await getUserSession();
 
     return (
-        <main>
+        <main className='max-w-screen-xl m-auto'>
             <h1 className='text-4xl font-bold ml-2 sm:ml-16 my-8 px-2 w-fit border-b border-black'>Dashboard</h1>
             
             <BracketLeagueSearch />

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import LeaguesDisplay from '@/app/ui/dashboard/leagues-display';
 import BracketsDisplay from '@/app/ui/dashboard/brackets-display';
+import BracketLeagueSearch from '@/app/ui/dashboard/bracket-league-search';
 import { getUserSession } from '@/app/lib/sessions';
 
 export const metadata: Metadata = {
@@ -16,7 +17,9 @@ export default async function Page() {
         <main>
             <h1 className='text-4xl font-bold ml-2 sm:ml-16 my-8 px-2 w-fit border-b border-black'>Dashboard</h1>
             
-            <section className='mb-16 max-w-screen-xl m-auto'>
+            <BracketLeagueSearch />
+
+            <section className='mt-8 mb-16 max-w-screen-xl m-auto'>
                 <LeaguesDisplay user={user} />
             </section>
 

--- a/app/dashboard/search/page.tsx
+++ b/app/dashboard/search/page.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import BracketLeagueSearch from "@/app/ui/dashboard/bracket-league-search";
 import SearchResults from "@/app/ui/dashboard/search/search-results";
 import { Suspense } from "react";

--- a/app/dashboard/search/page.tsx
+++ b/app/dashboard/search/page.tsx
@@ -1,22 +1,17 @@
 'use client'
 
-import { useSearchParams } from "next/navigation";
 import BracketLeagueSearch from "@/app/ui/dashboard/bracket-league-search";
 import SearchResults from "@/app/ui/dashboard/search/search-results";
+import { Suspense } from "react";
 
 export default function Page() {
-    const searchParams = useSearchParams();
-
-    let search = searchParams.get('q');
-    if (!search) {
-        search = " ";
-    }
-
     return (
     <div className="max-w-screen-xl m-auto">
         <h2 className='text-4xl font-bold ml-2 my-8 px-2 w-fit border-b border-black'>Results</h2>
         <BracketLeagueSearch />
-        <SearchResults search={search} />
+        <Suspense>
+            <SearchResults />
+        </Suspense>
     </div>
   );
 }

--- a/app/dashboard/search/page.tsx
+++ b/app/dashboard/search/page.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { useSearchParams } from "next/navigation";
+import BracketLeagueSearch from "@/app/ui/dashboard/bracket-league-search";
+import SearchResults from "@/app/ui/dashboard/search/search-results";
+
+export default function Page() {
+    const searchParams = useSearchParams();
+
+    let search = searchParams.get('q');
+    if (!search) {
+        search = " ";
+    }
+
+    return (
+    <div className="max-w-screen-xl m-auto">
+        <h2 className='text-4xl font-bold ml-2 my-8 px-2 w-fit border-b border-black'>Results</h2>
+        <BracketLeagueSearch />
+        <SearchResults search={search} />
+    </div>
+  );
+}

--- a/app/lib/data.ts
+++ b/app/lib/data.ts
@@ -395,7 +395,7 @@ export async function getBracketLeagueSearchResults(name: string) {
         `;
         return rows as BracketLeagueSearchResult[];
     } catch (error) {
-        console.log(error);
+        console.error(error);
         return [];
     }
 }

--- a/app/lib/data.ts
+++ b/app/lib/data.ts
@@ -2,7 +2,7 @@
 
 import { sql } from '@vercel/postgres';
 import { getUserSession } from '@/app/lib/sessions';
-import { CreateState, League, Bracket, User, Team, Game, GameWithTeamNames } from '@/app/lib/definitions';
+import { CreateState, League, Bracket, User, Team, Game, GameWithTeamNames, BracketLeagueSearchResult } from '@/app/lib/definitions';
 
 // Returns true if date2 is ahead of date1 by a year. With precision down to the day
 function isAheadAYear(date1: Date, date2: Date) {
@@ -370,6 +370,32 @@ export async function getLeagueGamesInRange(league_id: string, start_date: Date,
         return rows as GameWithTeamNames[];
     } catch (error) {
         console.error(error);
+        return [];
+    }
+}
+
+export async function getBracketLeagueSearchResults(name: string) {
+    try {
+        const { rows } = await sql`
+            SELECT name, description, start_date, end_date, 
+                CASE 
+                    WHEN league_id IS NOT NULL THEN league_id 
+                    ELSE bracket_id 
+                END AS id,
+                CASE 
+                    WHEN league_id IS NOT NULL THEN 'league' 
+                    ELSE 'bracket' 
+                END AS type
+            FROM (
+                SELECT name, description, start_date, end_date, league_id, NULL AS bracket_id FROM leagues
+                UNION ALL
+                SELECT name, description, start_date, end_date, NULL AS league_id, bracket_id FROM brackets
+            ) AS combined_entries
+            WHERE name ILIKE ${'%' + name + '%'}
+        `;
+        return rows as BracketLeagueSearchResult[];
+    } catch (error) {
+        console.log(error);
         return [];
     }
 }

--- a/app/lib/definitions.ts
+++ b/app/lib/definitions.ts
@@ -106,3 +106,12 @@ export type GameWithTeamNames = {
     game_time: Date,
     status: string,
 };
+
+export type BracketLeagueSearchResult = {
+        name: string,
+        description: string,
+        start_date: Date,
+        end_date: Date,
+        id: string,
+        type: string,
+};

--- a/app/ui/dashboard/bracket-league-search.tsx
+++ b/app/ui/dashboard/bracket-league-search.tsx
@@ -1,0 +1,17 @@
+export default function BracketLeagueSearch() {
+    return (
+        <form action="" className="p-4 flex flex-col items-center">
+
+            <label htmlFor="search" className="text-3xl font-semibold">Search</label>
+            <div className="flex max-w-[500px] w-full p-2 border rounded-xl">
+                <input type="text" id="search" name="search" placeholder="Search teams..." maxLength={255} className="p-2 w-full focus:outline-none"/>
+                <button type="submit">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="size-6">
+                        <path strokeLinecap="round" strokeLinejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
+                    </svg>
+                </button>
+            </div>
+        </form>
+        
+    );
+}

--- a/app/ui/dashboard/bracket-league-search.tsx
+++ b/app/ui/dashboard/bracket-league-search.tsx
@@ -1,17 +1,31 @@
-export default function BracketLeagueSearch() {
-    return (
-        <form action="" className="p-4 flex flex-col items-center">
+'use client'
 
-            <label htmlFor="search" className="text-3xl font-semibold">Search</label>
-            <div className="flex max-w-[500px] w-full p-2 border rounded-xl">
-                <input type="text" id="search" name="search" placeholder="Search teams..." maxLength={255} className="p-2 w-full focus:outline-none"/>
-                <button type="submit">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="size-6">
-                        <path strokeLinecap="round" strokeLinejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
-                    </svg>
-                </button>
-            </div>
-        </form>
+import { useRouter } from "next/navigation";
+
+export default function BracketLeagueSearch() {
+    const router = useRouter();
+    const handleClick = (form: FormData) => {
+        const searchInput = form.get('search');
+        if (searchInput) {
+            router.push(`/dashboard/search?q=${encodeURIComponent(searchInput.toString().trim())}`);
+        }
+    };
+
+    return (
+        <search>
+            <form action={handleClick} className="p-4 flex flex-col items-center">
+
+                <label htmlFor="search" className="text-3xl font-semibold">Search</label>
+                <div className="flex max-w-[500px] w-full p-2 border rounded-xl">
+                    <input type="text" id="search" name="search" placeholder="Search brackets & leagues..." maxLength={255} className="p-2 w-full focus:outline-none"/>
+                    <button type="submit">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="size-6">
+                            <path strokeLinecap="round" strokeLinejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
+                        </svg>
+                    </button>
+                </div>
+            </form>
+        </search>
         
     );
 }

--- a/app/ui/dashboard/search/search-results.tsx
+++ b/app/ui/dashboard/search/search-results.tsx
@@ -4,10 +4,17 @@ import { getBracketLeagueSearchResults } from "@/app/lib/data";
 import { BracketLeagueSearchResult } from "@/app/lib/definitions";
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 
-export default function SearchResults({search} : {search: string}) {
+export default function SearchResults() {
     const [results, setResults] = useState<BracketLeagueSearchResult[]>([]);
+    const searchParams = useSearchParams();
     
+    let search = searchParams.get('q');
+    if (!search) {
+        search = " ";
+    }
+
     useEffect(() => {
         const fetchResults = async () => {
             const newResults = await getBracketLeagueSearchResults(search);

--- a/app/ui/dashboard/search/search-results.tsx
+++ b/app/ui/dashboard/search/search-results.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import { getBracketLeagueSearchResults } from "@/app/lib/data";
+import { BracketLeagueSearchResult } from "@/app/lib/definitions";
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+export default function SearchResults({search} : {search: string}) {
+    const [results, setResults] = useState<BracketLeagueSearchResult[]>([]);
+    
+    useEffect(() => {
+        const fetchResults = async () => {
+            const newResults = await getBracketLeagueSearchResults(search);
+            setResults(newResults);
+        };
+
+        fetchResults();
+    }, [search]);
+
+    return (
+        <div>
+            <h3 className="text-lg font-semibold text-blue-500">
+                Results for: <span className="text-black">{search}</span>
+            </h3>
+            { results.length === 0 ? <div className="mt-8 text-center text-lg">No results matched your search</div> :
+                <ul className="mt-4 mx-4">
+                    {results.map((result) => (
+                        <li key={result.id+result.type} className="flex flex-row  justify-between items-center border p-4 rounded-xl my-2">
+                            <div className="flex flex-col">
+                                <Link href={result.type === 'league' ? `/dashboard/leagues/${result.id}` : `/dashboard/brackets/${result.id}`}
+                                    className="font-semibold hover:text-red-500 duration-100">
+                                    {result.name}
+                                </Link>
+                                <p className="text-gray-500 text-sm">{result.description}</p>
+                            </div>
+                            {
+                                result.type === "bracket" ? <span className="bg-red-400 h-min text-white w-min p-2 rounded-lg">Bracket</span> :
+                                <span className="bg-blue-400 h-min text-white w-min p-2 rounded-lg">League</span>
+                        
+                            }
+                        </li>
+                    ))}
+                </ul>
+            }
+        </div>
+    );
+}


### PR DESCRIPTION
Added in Search bar for brackets and leagues to the dashboard page.

- When user searches they are brought to path 'dashboard/search' where search results are displayed in a list.
- list items have links that direct to the respective league or bracket pages.
- users can also access search bar from the search results page 